### PR TITLE
Added high-level diagrams

### DIFF
--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,12 @@
+```mermaid
+graph LR
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
# Pull Request

This PR contains high-level diagrams for the phase1b's codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/phase1b/on_boarding.md

The idea of these diagrams are to help people get up-to-speed with the codebase. I know that a lot of scientists interact with these codebases and I suppose they can make use of such diagrams and grasp the idea much faster than reading the code itself. I would love to hear what do you think about diagram first documentation for on-boarding and if it fits in your existing on-boarding processes. And also automatically generated documentation, so that it is always up-to-date. We are working on github action, which will allow you to do so!

Any feedback is more than welcome! 

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.